### PR TITLE
allow to define hosts with no endpoint for ping only checks

### DIFF
--- a/roles/icinga2_hostconfig/tasks/main.yml
+++ b/roles/icinga2_hostconfig/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: gather master facts
+  setup:
+    gather_subset: all
+  delegate_to: "{{ groups.icinga2master|first }}"
+
 - name: Include OS specific vars
   include_vars: "{{ ansible_os_family }}.yml"
 

--- a/roles/icinga2_hostconfig/templates/host.conf.j2
+++ b/roles/icinga2_hostconfig/templates/host.conf.j2
@@ -9,7 +9,11 @@ object Host "{{ inventory_hostname }}" {
   import "generic-host"
   {% endif %}
 
+  {% if not icinga_hv_network_device|default(false) %}
   vars.client_endpoint = name
+  {% else %}
+  # no vars.client_endpoint: ping only device #}
+  {% endif %}
 
   {% if icinga_zone is defined or icinga_is_satellite|default(false) %}
   vars.is_satellite = true
@@ -81,6 +85,9 @@ object Host "{{ inventory_hostname }}" {
 
 }
 
+{% if not icinga_hv_network_device|default(false) %}
+{# don't define endpoint and zone for network devices #}
+
 {% if inventory_hostname not in groups.icinga2master %}
 object Endpoint "{{ inventory_hostname }}" {
     {% if inventory_hostname in groups.dmz|default([]) %}
@@ -99,5 +106,6 @@ object Zone "{{ icinga_zone|default(inventory_hostname) }}" {
   endpoints = [ "{{ inventory_hostname }}" ]
 
 }
+{% endif %}
 {% endif %}
 {% endif %}

--- a/roles/icinga2_hostconfig/templates/host.conf.j2
+++ b/roles/icinga2_hostconfig/templates/host.conf.j2
@@ -35,6 +35,7 @@ object Host "{{ inventory_hostname }}" {
   {% endfor %}
   {% endif %}
 
+  {% if not icinga_hv_network_device|default(false) %}
   /* Set custom attribute `os` for hostgroup assignment in `groups.conf`. */
   vars.os = "{{ ansible_system }}"
   vars.ansible_os_family = "{{ ansible_os_family }}"
@@ -44,6 +45,7 @@ object Host "{{ inventory_hostname }}" {
   vars.disks["disk"] = {
     /* No parameters. */
   }
+  {% endif %}
 
   /* Notify by e-mail to the following groups */
   vars.notification.mail.groups = {{ icinga_mail_notification_groups }}


### PR DESCRIPTION
Set icinga_hv_network_device: true to disable the endpoint for a host. Only the hostalive (ping) check will run against this host, which is useful for network devices.